### PR TITLE
Multiple output codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,18 @@ dune_enable_all_packages(INCLUDE_DIRS ${dune-xt-common_SOURCE_DIR}/dune
                          MODULE_LIBRARIES dunextcommon gtest_dune_xt_common
                          )
 
+include(DuneXTInstallPythonPackage)
+# this symlinks all files in python/ to the binary dir and install into the virtualenv from there
+# thereby making the compiled extensions directly usable from the venv
+dune_xt_install_python_package(PATH python)
+include_dependent_binary_python_dirs()
+# do not change order here
 include(DuneUtils)
+if(dune-pybindxi_FOUND)
+  add_subdirectory(python)
+endif()
+
+
 include(GridUtils)
 
 add_header_listing()
@@ -68,15 +79,7 @@ add_subdirectory(dune)
 add_subdirectory("cmake/modules")
 add_subdirectory(doc/doxygen)
 
-include(DuneXTInstallPythonPackage)
-# this symlinks all files in python/ to the binary dir and install into the virtualenv from there
-# thereby making the compiled extensions directly usable from the venv
-dune_xt_install_python_package(PATH python)
-include_dependent_binary_python_dirs()
-# do not change order here
-if(dune-pybindxi_FOUND)
-  add_subdirectory(python)
-endif()
+
 
 
 

--- a/cmake/modules/DuneXTInstallPythonPackage.cmake
+++ b/cmake/modules/DuneXTInstallPythonPackage.cmake
@@ -1,3 +1,5 @@
+# DO NOT INCLUDE DuneUtils.cmake in this file
+
 # copy from dune-python with adjusted install path and such
 function(dune_xt_execute_process)
   include(CMakeParseArguments)

--- a/python/dune/xt/codegen.py
+++ b/python/dune/xt/codegen.py
@@ -21,7 +21,7 @@ def typeid_to_typedef_name(typeid, replacement='_'):
 def is_found(cache, name):
     if name in cache.keys():
         return 'notfound' not in cache[name].lower()
-    return false
+    return False
 
 
 def have_eigen(cache):


### PR DESCRIPTION
See https://github.com/dune-community/dune-xt-common/commit/835f7830516f8ec2c82e08acd7b59faf869be24c for an example on how to adjust a testcase to generate more than one file from a template. That commit will not be merged though, it's nonsense to split that test up. 