### PR TITLE
Deprecation stuff and things

### DIFF
--- a/dune/xt/common/crtp.hh
+++ b/dune/xt/common/crtp.hh
@@ -14,6 +14,8 @@
 #include <atomic>
 #include <mutex>
 
+#include <dune/xt/common/deprecated.hh>
+
 #include "exceptions.hh"
 
 #ifdef CHECK_CRTP
@@ -60,7 +62,7 @@
 
 namespace Dune {
 namespace XT {
-
+namespace Common {
 
 template <class InterfaceType, class TraitsImp>
 class CRTPInterface
@@ -92,6 +94,7 @@ public:
 protected:
   // nicely avoid warning about non-virtual dtor when derived classes have vfunc
   ~CRTPInterface() = default;
+
 #ifndef NDEBUG
   // needs to be static so diff instances don't clash in function local crtp check
   static std::recursive_mutex crtp_mutex_;
@@ -103,8 +106,12 @@ protected:
 template <class I, class T>
 std::recursive_mutex CRTPInterface<I, T>::crtp_mutex_;
 #endif
+} // namespace Common
 
 
+template <class I, class T>
+using CRTPInterface DXT_DEPRECATED_MSG("CRTPInterface was moved into Dune::XT:Common namespace (2018/3/16)") =
+    Common::CRTPInterface<I, T>;
 } // namespace XT
 } // namespace Dune
 

--- a/dune/xt/common/deprecated.hh
+++ b/dune/xt/common/deprecated.hh
@@ -1,0 +1,58 @@
+// This file is part of the dune-xt-common project:
+//   https://github.com/dune-community/dune-xt-common
+// Copyright 2009-2018 dune-xt-common developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Rene Milk       (2018)
+
+#ifndef DUNE_XT_COMMON_DEPRECATED_HH
+#define DUNE_XT_COMMON_DEPRECATED_HH
+
+#include <dune/common/deprecated.hh>
+
+/** usage examples
+
+ // Deprecate a function
+DXT_DEPRECATED
+void foo();
+
+// Deprecate a variable
+DXT_DEPRECATED
+int x;
+
+// Deprecate one declarator in a multi-declarator declaration
+int y DXT_DEPRECATED, z;
+
+// Deprecate a function parameter
+int triple(DXT_DEPRECATED int x);
+
+// Deprecate a class (or struct)
+class DXT_DEPRECATED my_class {
+  public:
+    // Deprecate a member
+    DXT_DEPRECATED int member;
+};
+
+// Deprecate an enum
+enum DXT_DEPRECATED animals {
+  CAT, DOG, MOUSE
+};
+
+// Deprecate a typedef
+DXT_DEPRECATED
+typedef int type;
+
+// Deprecate a template specialization
+template <typename T> class templ;
+
+template <>
+class DXT_DEPRECATED templ<int> {};
+
+ */
+
+#define DXT_DEPRECATED [[deprecated]]
+#define DXT_DEPRECATED_MSG(text) [[deprecated(#text)]]
+
+#endif // DUNE_XT_COMMON_DEPRECATED_HH

--- a/dune/xt/common/exceptions.hh
+++ b/dune/xt/common/exceptions.hh
@@ -14,7 +14,7 @@
 
 #include <dune/common/exceptions.hh>
 #include <dune/common/parallel/mpihelper.hh>
-#include <dune/common/deprecated.hh>
+#include <dune/xt/common/deprecated.hh>
 
 #ifdef DUNE_THROW
 #undef DUNE_THROW
@@ -137,7 +137,8 @@ class parameter_error : public Dune::Exception
 {
 };
 
-class spe10_data_file_missing : public Dune::IOError
+class DXT_DEPRECATED_MSG("moved into dune-xt-functions Dune::XT::Functions::Exceptions (2018/03/16")
+    spe10_data_file_missing : public Dune::IOError
 {
 };
 

--- a/dune/xt/common/exceptions.hh
+++ b/dune/xt/common/exceptions.hh
@@ -137,6 +137,10 @@ class parameter_error : public Dune::Exception
 {
 };
 
+class spe10_data_file_missing : public Dune::IOError
+{
+};
+
 class dependency_missing : public Dune::Exception
 {
 };

--- a/dune/xt/common/parameter.hh
+++ b/dune/xt/common/parameter.hh
@@ -19,7 +19,7 @@
 #include <sstream>
 #include <ostream>
 
-#include <dune/common/deprecated.hh>
+#include <dune/xt/common/deprecated.hh>
 
 namespace Dune {
 namespace XT {
@@ -155,7 +155,7 @@ public:
 
   Parameter parse_parameter(const Parameter& mu) const;
 
-  Parameter DUNE_DEPRECATED_MSG("Use parse_parameter instead (28.08.2017)!") parse_and_check(const Parameter& mu) const;
+  DXT_DEPRECATED_MSG("Use parse_parameter instead (28.08.2017)!") Parameter parse_and_check(const Parameter& mu) const;
 
 private:
   ParameterType parameter_type_;

--- a/dune/xt/common/test/crtp.cc
+++ b/dune/xt/common/test/crtp.cc
@@ -1,0 +1,78 @@
+// This file is part of the dune-xt-common project:
+//   https://github.com/dune-community/dune-xt-common
+// Copyright 2009-2018 dune-xt-common developers and contributors. All rights reserved.
+// License: Dual licensed as BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
+//      or  GPL-2.0+ (http://opensource.org/licenses/gpl-license)
+//          with "runtime exception" (http://www.dune-project.org/license.html)
+// Authors:
+//   Rene Milk       (2018)
+
+// This one has to come first (includes the config.h)!
+#include <dune/xt/common/test/main.hxx>
+
+#include <dune/xt/common/crtp.hh>
+
+template <class Traits>
+class TestInterface;
+
+struct FailTraits
+{
+  using BackendType = double;
+  using derived_type = TestInterface<FailTraits>;
+};
+
+class TestImp;
+
+struct ImpTraits
+{
+  using BackendType = double;
+  using derived_type = TestImp;
+};
+
+template <class Traits>
+class TestInterface : public Dune::XT::Common::CRTPInterface<TestInterface<Traits>, Traits>
+{
+public:
+  typedef typename Traits::BackendType BackendType;
+
+  inline BackendType& backend()
+  {
+    CHECK_CRTP(this->as_imp().backend());
+    return this->as_imp().backend();
+  }
+
+  inline const BackendType& backend() const
+  {
+    CHECK_CRTP(this->as_imp().backend());
+    return this->as_imp().backend();
+  }
+}; // class ProvidesBackend
+
+
+struct TestImp : public TestInterface<ImpTraits>
+{
+  using BackendType = ImpTraits::BackendType;
+  BackendType foo_;
+
+  inline BackendType& backend()
+  {
+    return foo_;
+  }
+
+  inline const BackendType& backend() const
+  {
+    return foo_;
+  }
+};
+
+GTEST_TEST(crtp, fail)
+{
+  TestInterface<FailTraits> test_iface;
+  EXPECT_THROW({ auto& st = test_iface.backend(); }, Dune::XT::Common::Exceptions::CRTP_check_failed);
+}
+
+GTEST_TEST(crtp, success)
+{
+  TestImp test_imp;
+  auto& st = test_imp.backend();
+}


### PR DESCRIPTION
This reverts commit e54351e28b781b34d3ec9a9a6fa18d575a519ac4.

It would be better if we could move classes only with
deprecation warning in place for a while.