### PR TITLE
[WIP] [cmake] ignore (symlinked) header in bindir for headercheck

### DIFF
--- a/cmake/modules/DuneXTTesting.cmake
+++ b/cmake/modules/DuneXTTesting.cmake
@@ -7,6 +7,8 @@ macro(dxt_headercheck_target_name arg)
 endmacro(dxt_headercheck_target_name)
 
 macro(get_headercheck_targets)
+  file(GLOB_RECURSE bindir_header "${CMAKE_BINARY_DIR}/*.hh")
+  list(APPEND dxt_ignore_header ${bindir_header})
 # this is mostly c&p from dune-common, since we need a way to extract
 # all target names to pass to our load balancing script
   if(ENABLE_HEADERCHECK)


### PR DESCRIPTION
This greatly confused the binning script otherwise.

If @tobiasleibner has some idea on how to make the refresh stuff easier to manage, that would be appreciated. 