### PR TITLE
[threadmanager] fix thread numbering

### DIFF
--- a/dune/xt/common/parallel/threadstorage.hh
+++ b/dune/xt/common/parallel/threadstorage.hh
@@ -90,6 +90,11 @@ public:
     return values_[threadManager().thread()].get();
   }
 
+  auto& get_pointer()
+  {
+      return values_[threadManager().thread()];
+  }
+
   template <class BinaryOperation>
   ValueType accumulate(ValueType init, BinaryOperation op) const
   {


### PR DESCRIPTION
Using ``thread_ids.size()`` as index for the current thread is not thread-safe, so use an atomic counter instead. Also adds convenience function to access ```PerThreadValue```s pointer in each thread.