### PR TITLE
Dailywork tim

### DIFF
--- a/python/dune/xt/common/fmatrix.hh
+++ b/python/dune/xt/common/fmatrix.hh
@@ -78,6 +78,12 @@ struct type_caster<Dune::FieldMatrix<K, N, M>> : public FieldMatrix_type_caster<
 {
 };
 
+/**
+ * Dune::XT::Common::FieldMatrix is already able to handle std::string as we already provide the correct default value
+ * (see type_traits::suitable_default). Thus, we do not need to initalize with value *= K(0.0)
+ *
+ * Attention: If this is not enough you need to specialize for std::string. (see fvector.hh)
+ */
 template <class K, int N, int M>
 struct type_caster<Dune::XT::Common::FieldMatrix<K, N, M>>
     : public FieldMatrix_type_caster<Dune::XT::Common::FieldMatrix<K, N, M>>

--- a/python/dune/xt/common/fvector.hh
+++ b/python/dune/xt/common/fvector.hh
@@ -65,6 +65,11 @@ struct FieldVector_type_caster
   PYBIND11_TYPE_CASTER(type, _("List[") + value_conv::name() + _("[") + _<SZ>() + _("]]"));
 }; // struct FieldVector_type_caster
 
+/**
+ * This specialization is needed because we also want to have std::string in FieldVector.
+ * For Dune::XT::Common::FieldMatrix we already have the correct default value, so no string version of value *= K(0.0)
+ * is required
+ **/
 template <class FieldVectorImp>
 struct FieldVector_type_caster<FieldVectorImp, false>
 {

--- a/python/dune/xt/common/fvector.hh
+++ b/python/dune/xt/common/fvector.hh
@@ -20,7 +20,9 @@ NAMESPACE_BEGIN(pybind11)
 NAMESPACE_BEGIN(detail)
 
 
-template <class FieldVectorImp>
+template <class FieldVectorImp,
+          bool is_number = (Dune::XT::Common::is_arithmetic<typename FieldVectorImp::value_type>::value
+                            || Dune::XT::Common::is_complex<typename FieldVectorImp::value_type>::value)>
 struct FieldVector_type_caster
 {
   using type = FieldVectorImp;
@@ -37,6 +39,48 @@ struct FieldVector_type_caster
       return false;
     value_conv conv;
     value *= K(0.0);
+    size_t ii = 0;
+    for (auto it : s) {
+      if (ii >= SZ)
+        return false;
+      if (!conv.load(it, convert))
+        return false;
+      value[ii++] = cast_op<K>(conv);
+    }
+    return true;
+  } // ... load(...)
+
+  static handle cast(const type& src, return_value_policy policy, handle parent)
+  {
+    list l(SZ);
+    for (size_t ii = 0; ii < src.size(); ++ii) {
+      object val = reinterpret_steal<object>(value_conv::cast(src[ii], policy, parent));
+      if (!val)
+        return handle();
+      PyList_SET_ITEM(l.ptr(), ii, val.release().ptr()); // steals a reference
+    }
+    return l.release();
+  } // ... cast(...)
+
+  PYBIND11_TYPE_CASTER(type, _("List[") + value_conv::name() + _("[") + _<SZ>() + _("]]"));
+}; // struct FieldVector_type_caster
+
+template <class FieldVectorImp>
+struct FieldVector_type_caster<FieldVectorImp, false>
+{
+  using type = FieldVectorImp;
+  typedef typename type::value_type K;
+  static const int SZ = type::dimension;
+  using value_conv = make_caster<K>;
+
+  bool load(handle src, bool convert)
+  {
+    if (!isinstance<sequence>(src))
+      return false;
+    auto s = reinterpret_borrow<sequence>(src);
+    if (s.size() != SZ)
+      return false;
+    value_conv conv;
     size_t ii = 0;
     for (auto it : s) {
       if (ii >= SZ)


### PR DESCRIPTION
Allow for std::string in the python bindings for FieldVector and FieldMatrix.
Required for python bindings for ExpressionFunction. 