### PR TITLE
[py] install codecov as a dependency

### DIFF
--- a/.gitsuper
+++ b/.gitsuper
@@ -1,33 +1,34 @@
 [supermodule]
-remote = git@github.com:dune-community/dune-xt-super.git
+remote = git@github.com:dune-community/dune-gdt-super.git
 status = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8 bin (heads/master)
-	 20a673b9dad7e2e25bd97defa8849debb59d247c config.opts (heads/master-8-g20a673b)
+	 20a673b9dad7e2e25bd97defa8849debb59d247c config.opts (heads/master)
 	 8f2c5aba441417bf2c42f22272f538c68a89cc4a dune-alugrid (remotes/origin/releases/2.5)
 	 707acf201d5a754c80f87cc4d71aa36bf29a6e3f dune-common (v2.5.1-9-g707acf20)
-	 e6350271b8d014adab51467a35b6ad8ef48212a0 dune-geometry (v2.5.1-6-ge635027)
+	+133d58e55e8aa771cfddc4fe8a9606dd917e5c46 dune-gdt (heads/drone_setup)
+	 390a2c503783bbed778a8ff610f8c5ca09c238d0 dune-geometry (v2.5.1-5-g390a2c5)
 	 d7b20bbc5f6fdcfc312beb0ea5d16d39ea26904e dune-grid (v2.5.1-2-gd7b20bbc5)
-	 e9d9a3336735090648637e044e279866bbea3597 dune-grid-glue (v2.4.0-60-ge9d9a33)
+	 9e29a333e8af02382d80b95335a784d5ce1ea2c8 dune-grid-glue (v2.4.0-70-g9e29a33)
 	 63df56a54f81eda308233a683eb329e77e69f0a9 dune-istl (v2.5.1rc1)
 	 0d757d65e5d57134a7ecf304e35d063f4ccc7116 dune-localfunctions (v2.5.1rc1)
 	 8a69fc68165780921bbba77da338b6932daf983c dune-pybindxi (v2.2.1-16-g8a69fc6)
 	 741e4f8e53bdd3e1b6e19d84eb22b6e3dc48526c dune-python (remotes/origin/releases/2.5)
-	 26cc8cb4161a3a51002ab2a81b8c81d2c951ee79 dune-testtools (26cc8cb)
-	 8fe883e99c58c9f0c2f92457d546a0ac9f5a9bf9 dune-uggrid (v2.5.2-1-g8fe883e9)
-	 c5f8b4463e57dff3deb8c525335ee18a44508808 dune-xt-common (heads/master)
-	+637b90765f523a11041111095e838dc2e235928d dune-xt-data (heads/python_ci)
-	+965d05291cea0b76db422d56777d7084983ea2f2 dune-xt-functions (heads/python_ci)
-	+565d551040f6091652436fd461c7689c1fa5315b dune-xt-grid (heads/python_ci)
-	+2f0e523102877547b4cc18b9ede955e2bb31a04e dune-xt-la (heads/python_ci)
+	 26cc8cb4161a3a51002ab2a81b8c81d2c951ee79 dune-testtools (remotes/origin/p/renemilk/testname_listing_hack_no-skiptest)
+	 0a74e7dd0b2115778a5d490dab08a2ed07fcaa1e dune-uggrid (v2.5.2)
+	+8d926c61360725a58467cd586f2ef6cfce0a22be dune-xt-common (heads/install_codecov)
+	 8668818754df182fd73cec1538c0bbe233c8851c dune-xt-data (remotes/origin/HEAD)
+	 83b29cbe84d0af6579d6904f59598ad3dd132996 dune-xt-functions (heads/master)
+	 d4d2b463a75b557fdec45069c1f43b20b40b6265 dune-xt-grid (remotes/origin/HEAD)
+	 3c2499d9a3267f7d0a23efd2fa7dfdf073dfa671 dune-xt-la (remotes/origin/HEAD)
 	 09d0378f616b94d68bcdd9fc6114813181849ec0 scripts (remotes/origin/HEAD)
-commit = d26d954a3dc84a448e17431910e573c148e0187e
+commit = aa711b3a604af1aef4a3ebd449508814e3504843
 
 [submodule.bin]
-remote = git@github.com:dune-community/local-bin.git
+remote = https://github.com/dune-community/local-bin.git
 status = 
 commit = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8
 
 [submodule.config.opts]
-remote = git@github.com:dune-community/config.opts.git
+remote = https://github.com/dune-community/config.opts.git
 status = 
 commit = 20a673b9dad7e2e25bd97defa8849debb59d247c
 
@@ -37,37 +38,42 @@ status =
 commit = 8f2c5aba441417bf2c42f22272f538c68a89cc4a
 
 [submodule.dune-common]
-remote = git@github.com:dune-community/dune-common.git
+remote = https://github.com/dune-community/dune-common.git
 status = 
 commit = 707acf201d5a754c80f87cc4d71aa36bf29a6e3f
 
+[submodule.dune-gdt]
+remote = https://github.com/dune-community/dune-gdt.git
+status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (remotes/origin/HEAD)
+commit = 133d58e55e8aa771cfddc4fe8a9606dd917e5c46
+
 [submodule.dune-geometry]
-remote = http://github.com/dune-community/dune-geometry.git
+remote = https://github.com/dune-community/dune-geometry.git
 status = 
-commit = e6350271b8d014adab51467a35b6ad8ef48212a0
+commit = 390a2c503783bbed778a8ff610f8c5ca09c238d0
 
 [submodule.dune-grid]
-remote = http://github.com/dune-community/dune-grid.git
+remote = https://github.com/dune-community/dune-grid.git
 status = 
 commit = d7b20bbc5f6fdcfc312beb0ea5d16d39ea26904e
 
 [submodule.dune-grid-glue]
 remote = https://github.com/dune-mirrors/dune-grid-glue.git
 status = 
-commit = e9d9a3336735090648637e044e279866bbea3597
+commit = 9e29a333e8af02382d80b95335a784d5ce1ea2c8
 
 [submodule.dune-istl]
-remote = http://github.com/dune-mirrors/dune-istl.git
+remote = https://github.com/dune-mirrors/dune-istl.git
 status = 
 commit = 63df56a54f81eda308233a683eb329e77e69f0a9
 
 [submodule.dune-localfunctions]
-remote = http://github.com/dune-mirrors/dune-localfunctions.git
+remote = https://github.com/dune-mirrors/dune-localfunctions.git
 status = 
 commit = 0d757d65e5d57134a7ecf304e35d063f4ccc7116
 
 [submodule.dune-pybindxi]
-remote = git@github.com:dune-community/dune-pybindxi.git
+remote = https://github.com/dune-community/dune-pybindxi.git
 status = a18500d497d2ffa2f627bc6e7da0aa1169b81ea3 .vcsetup (a18500d)
 commit = 8a69fc68165780921bbba77da338b6932daf983c
 
@@ -77,39 +83,39 @@ status =
 commit = 741e4f8e53bdd3e1b6e19d84eb22b6e3dc48526c
 
 [submodule.dune-testtools]
-remote = https://github.com/dune-mirrors/dune-testtools.git
+remote = https://github.com/dune-community/dune-testtools.git
 status = 
 commit = 26cc8cb4161a3a51002ab2a81b8c81d2c951ee79
 
 [submodule.dune-uggrid]
 remote = https://github.com/dune-mirrors/dune-uggrid.git
 status = 
-commit = 8fe883e99c58c9f0c2f92457d546a0ac9f5a9bf9
+commit = 0a74e7dd0b2115778a5d490dab08a2ed07fcaa1e
 
 [submodule.dune-xt-common]
-remote = git@github.com:dune-community/dune-xt-common.git
+remote = https://github.com/dune-community/dune-xt-common.git
 status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (remotes/origin/HEAD)
-commit = c5f8b4463e57dff3deb8c525335ee18a44508808
+commit = 8d926c61360725a58467cd586f2ef6cfce0a22be
 
 [submodule.dune-xt-data]
 remote = https://github.com/dune-community/dune-xt-data
 status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (heads/master)
-commit = 637b90765f523a11041111095e838dc2e235928d
+commit = 8668818754df182fd73cec1538c0bbe233c8851c
 
 [submodule.dune-xt-functions]
-remote = git@github.com:dune-community/dune-xt-functions.git
+remote = https://github.com/dune-community/dune-xt-functions.git
 status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (remotes/origin/HEAD)
-commit = 965d05291cea0b76db422d56777d7084983ea2f2
+commit = 83b29cbe84d0af6579d6904f59598ad3dd132996
 
 [submodule.dune-xt-grid]
-remote = git@github.com:dune-community/dune-xt-grid.git
+remote = https://github.com/dune-community/dune-xt-grid.git
 status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (remotes/origin/HEAD)
-commit = 565d551040f6091652436fd461c7689c1fa5315b
+commit = d4d2b463a75b557fdec45069c1f43b20b40b6265
 
 [submodule.dune-xt-la]
-remote = git@github.com:dune-community/dune-xt-la.git
+remote = https://github.com/dune-community/dune-xt-la.git
 status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (remotes/origin/HEAD)
-commit = 2f0e523102877547b4cc18b9ede955e2bb31a04e
+commit = 3c2499d9a3267f7d0a23efd2fa7dfdf073dfa671
 
 [submodule.scripts]
 remote = https://github.com/wwu-numerik/scripts.git

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -17,7 +17,8 @@ import sys
 from setuptools import setup, find_packages
 
 requires=['binpacking==1.3', 'cython', 'jinja2', 'docopt', 'pylicense3>=0.3.0',
-                        'ipython', 'pytest', 'pytest-cov', 'cmake_format==0.4.1']
+                        'ipython', 'pytest', 'pytest-cov', 'cmake_format==0.4.1',
+                        'codecov']
 if '${HAVE_MPI}' == 'TRUE':
     requires.append('mpi4py')
 


### PR DESCRIPTION
currently every downstream module had it install from
the CI script