### PR TITLE
[parallel.helper] Add include

### DIFF
--- a/.gitsuper
+++ b/.gitsuper
@@ -1,53 +1,60 @@
 [supermodule]
-remote = zivgitlab.uni-muenster.de:falbr_01/parabolic-lrbms-2017-code.git
-status = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8 bin (remotes/origin/HEAD)
-	+9c6b620ce5cfd7b76aa325a58f68dd19b22b4486 config.opts (heads/master)
-	+76d7f0c9886a061571cb8dc66dd45a4ef86e7a58 dune-common (v2.2.1-2269-g76d7f0c9)
-	+5736d9ef769473ab160d1e03f58fb7bd851dd15a dune-gdt (heads/foo)
-	+0679771e839dd4a4a8fe38a4fd20b55fe82e876b dune-geometry (v2.6.0-14-g0679771)
-	+83a70bf70c3815e57e55b9b8eb99dd2522047385 dune-grid (v2.6.0-10-g83a70bf70)
-	+1369ae9329d0928480d6b18ed772fc77e1abf752 dune-grid-glue (v2.4.0-161-g1369ae9)
-	+bb0fee9783873261b7d211d755b32655e0cc7009 dune-istl (v2.6.0-6-gbb0fee97)
-	+ee794bfdfa3d4f674664b4155b6b2df36649435f dune-localfunctions (v2.6.0-4-gee794bf)
-	+e66c44d6b31fe0994ffb7705cd00e1f853289724 dune-pybindxi (v2.2.1-23-ge66c44d)
-	+58bd932e2311a288e0163d041f836b50f19111cb dune-testtools (heads/testname_listing_hack2.6)
-	+bf48b2929a26dc043925c41672570600b936f032 dune-xt-common (heads/fix-ambiguous-std-abs-overloads)
-	 cad4071f7722374d5131c21244970e93c98ad6ba dune-xt-data (heads/master)
-	+f896ab3de65c4fbaaaa078e96dd5e0f48581b80e dune-xt-functions (heads/master)
-	+bcfd27e9862bbbed3c357340f60e2f806ebf2339 dune-xt-grid (heads/master)
-	+0c3b93e32d48b7b389db1c3572d567bff272190c dune-xt-la (heads/master)
-	 bf4b95c2861bb9ba9fbb8e957113020088ebae29 pymor (0.1.0-3309-gbf4b95c2)
-commit = c44d346914c63ef91be2bfa5b289d54bff4fed2c
+remote = git@github.com:dune-community/dune-gdt-super.git
+status = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8 bin (heads/master)
+	 28c9ce81c14c878a71e907ab05b9bb72df77883e config.opts (heads/master)
+	 f308c6637edd65dcb83c4c1a46feaf05b958130e dune-alugrid (v2.6.0-7-gf308c663)
+	 76d7f0c9886a061571cb8dc66dd45a4ef86e7a58 dune-common (v2.2.1-2269-g76d7f0c9)
+	+9c16f3254375d6345692484f24949580ec6c5767 dune-gdt (heads/new-master)
+	 5235397bc16d24c759a1672fed7b8cfde4852e52 dune-geometry (v2.2.0-834-g5235397)
+	 af5766f0df47e3d0b62ea486efb9cdbf8e1cfc52 dune-grid (v2.2.0-2671-gaf5766f0d)
+	 1369ae9329d0928480d6b18ed772fc77e1abf752 dune-grid-glue (v2.4.0-161-g1369ae9)
+	 ef68ae0ec40f9d369e4ea9b31e560af6af545bf6 dune-istl (v2.6.0-4-gef68ae0e)
+	 5a1f77d7a0a41c2d065b29f00dda0871ec70337b dune-localfunctions (v2.6.0-2-g5a1f77d)
+	 6d2a4680493a2483d53f9dd05a19dd6b5f436572 dune-pybindxi (v2.2.1-30-g6d2a468)
+	 58bd932e2311a288e0163d041f836b50f19111cb dune-testtools (remotes/origin/testname_listing_hack2.6)
+	 07f9700459c616186737a9a34277f2edee76f475 dune-uggrid (v2.6.0-1-g07f97004)
+	 34bf11741a2607de3cd4fa8685269f1f20f9178b dune-xt-common (heads/dailywork_tleibner)
+	 0307552d17c4d383d218b8e1a2d1064a2768ddd7 dune-xt-data (heads/master)
+	 a78d5c61c829457c2b7f6a51ea7f9dbd7ad44b10 dune-xt-functions (heads/master)
+	 54c306274f4253477d0116490c0c812d6db1b31d dune-xt-grid (heads/master)
+	 82bef18a993f9a475b3b45d209def8e34e55e1fe dune-xt-la (heads/master)
+	 09d0378f616b94d68bcdd9fc6114813181849ec0 scripts (heads/master)
+commit = 161e088d4ce472e23873db7e2a1302d29ca40cb5
 
 [submodule.bin]
-remote = https://github.com/dune-community/local-bin.git
+remote = git@github.com:dune-community/local-bin.git
 status = 
 commit = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8
 
 [submodule.config.opts]
-remote = https://github.com/dune-community/config.opts.git
+remote = git@github.com:dune-community/config.opts.git
 status = 
-commit = 9c6b620ce5cfd7b76aa325a58f68dd19b22b4486
+commit = 28c9ce81c14c878a71e907ab05b9bb72df77883e
+
+[submodule.dune-alugrid]
+remote = https://github.com/dune-mirrors/dune-alugrid.git
+status = 
+commit = f308c6637edd65dcb83c4c1a46feaf05b958130e
 
 [submodule.dune-common]
-remote = https://github.com/dune-community/dune-common.git
+remote = git@github.com:dune-community/dune-common.git
 status = 
 commit = 76d7f0c9886a061571cb8dc66dd45a4ef86e7a58
 
 [submodule.dune-gdt]
-remote = git@zivgitlab.uni-muenster.de:srave_01/dune-gdt.git
-status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (remotes/origin/HEAD)
-commit = 5736d9ef769473ab160d1e03f58fb7bd851dd15a
+remote = git@github.com:dune-community/dune-gdt.git
+status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
+commit = 9c16f3254375d6345692484f24949580ec6c5767
 
 [submodule.dune-geometry]
-remote = https://github.com/dune-community/dune-geometry.git
+remote = git@github.com:dune-community/dune-geometry.git
 status = 
-commit = 0679771e839dd4a4a8fe38a4fd20b55fe82e876b
+commit = 5235397bc16d24c759a1672fed7b8cfde4852e52
 
 [submodule.dune-grid]
-remote = https://github.com/dune-community/dune-grid.git
+remote = git@github.com:dune-community/dune-grid.git
 status = 
-commit = 83a70bf70c3815e57e55b9b8eb99dd2522047385
+commit = af5766f0df47e3d0b62ea486efb9cdbf8e1cfc52
 
 [submodule.dune-grid-glue]
 remote = https://github.com/dune-mirrors/dune-grid-glue.git
@@ -57,50 +64,55 @@ commit = 1369ae9329d0928480d6b18ed772fc77e1abf752
 [submodule.dune-istl]
 remote = https://github.com/dune-mirrors/dune-istl.git
 status = 
-commit = bb0fee9783873261b7d211d755b32655e0cc7009
+commit = ef68ae0ec40f9d369e4ea9b31e560af6af545bf6
 
 [submodule.dune-localfunctions]
 remote = https://github.com/dune-mirrors/dune-localfunctions.git
 status = 
-commit = ee794bfdfa3d4f674664b4155b6b2df36649435f
+commit = 5a1f77d7a0a41c2d065b29f00dda0871ec70337b
 
 [submodule.dune-pybindxi]
-remote = https://github.com/dune-community/dune-pybindxi.git
-status = a18500d497d2ffa2f627bc6e7da0aa1169b81ea3 .vcsetup (a18500d)
-commit = e66c44d6b31fe0994ffb7705cd00e1f853289724
+remote = git@github.com:dune-community/dune-pybindxi.git
+status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
+commit = 6d2a4680493a2483d53f9dd05a19dd6b5f436572
 
 [submodule.dune-testtools]
-remote = https://github.com/dune-mirrors/dune-testtools.git
+remote = git@github.com:dune-community/dune-testtools.git
 status = 
 commit = 58bd932e2311a288e0163d041f836b50f19111cb
 
+[submodule.dune-uggrid]
+remote = https://github.com/dune-mirrors/dune-uggrid.git
+status = 
+commit = 07f9700459c616186737a9a34277f2edee76f475
+
 [submodule.dune-xt-common]
-remote = https://github.com/dune-community/dune-xt-common.git
-status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (remotes/origin/HEAD)
-commit = bf48b2929a26dc043925c41672570600b936f032
+remote = git@github.com:dune-community/dune-xt-common.git
+status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
+commit = 34bf11741a2607de3cd4fa8685269f1f20f9178b
 
 [submodule.dune-xt-data]
-remote = https://github.com/dune-community/dune-xt-data.git
-status = -c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup
-commit = cad4071f7722374d5131c21244970e93c98ad6ba
+remote = git@github.com:dune-community/dune-xt-data
+status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
+commit = 0307552d17c4d383d218b8e1a2d1064a2768ddd7
 
 [submodule.dune-xt-functions]
-remote = https://github.com/ftalbrecht/dune-xt-functions.git
-status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (remotes/origin/HEAD)
-commit = f896ab3de65c4fbaaaa078e96dd5e0f48581b80e
+remote = git@github.com:dune-community/dune-xt-functions.git
+status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
+commit = a78d5c61c829457c2b7f6a51ea7f9dbd7ad44b10
 
 [submodule.dune-xt-grid]
-remote = https://github.com/ftalbrecht/dune-xt-grid.git
-status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (remotes/origin/HEAD)
-commit = bcfd27e9862bbbed3c357340f60e2f806ebf2339
+remote = git@github.com:dune-community/dune-xt-grid.git
+status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
+commit = 54c306274f4253477d0116490c0c812d6db1b31d
 
 [submodule.dune-xt-la]
-remote = https://github.com/dune-community/dune-xt-la.git
-status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (remotes/origin/HEAD)
-commit = 0c3b93e32d48b7b389db1c3572d567bff272190c
+remote = git@github.com:dune-community/dune-xt-la.git
+status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
+commit = 82bef18a993f9a475b3b45d209def8e34e55e1fe
 
-[submodule.pymor]
-remote = git@zivgitlab.uni-muenster.de:srave_01/pymor.git
-status = 
-commit = bf4b95c2861bb9ba9fbb8e957113020088ebae29
+[submodule.scripts]
+remote = https://github.com/wwu-numerik/scripts.git
+status = fb5ebc10e647d637c69497af2ec2560847eb2112 python/pylicense (v0.2.0~10)
+commit = 09d0378f616b94d68bcdd9fc6114813181849ec0
 

--- a/dune/xt/common/parallel/helper.hh
+++ b/dune/xt/common/parallel/helper.hh
@@ -13,6 +13,7 @@
 #define DUNE_XT_COMMON_PARALLEL_HELPER_HH
 
 #include <type_traits>
+#include <cassert>
 
 #include <dune/common/parallel/collectivecommunication.hh>
 


### PR DESCRIPTION
Without this include, 'assert' was not defined for me in
dune/istl/paamg/pinfo.hh. Does not seem to be a problem on Travis, but
adding the include does not hurt.